### PR TITLE
update tag name to not collide with the new canonical repo in openshift-eng

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       uses: redhat-actions/buildah-build@v2.12
       with:
         image: nested-environment-builder
-        tags: latest ${{ github.sha }}
+        tags: openshift-splat-team ${{ github.sha }}
         dockerfiles: ./Containerfile
     # Podman Login action (https://github.com/redhat-actions/podman-login) also be used to log in,
     # in which case 'username' and 'password' can be omitted.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # nested-ova-ansible
 
+** https://github.com/openshift-eng/nested-ova-ansible is now the canonical repo **
+
 Provisions nested vCenter and ESXi hosts.
 
 ## Prerequisites


### PR DESCRIPTION
**Changes**

- Changed target tag for merged PRs to not collide with the canonical openshift-eng/nested-ova-ansible repo
- Updated README