### PR TITLE
Feature/vm host pinning

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,15 @@
+approvers:
+- jcpowermac
+- mtulio
+- rvanderp3
+- vr4manta
+- sgaoshang
+- WenXinWei
+options: {}
+reviewers:
+- jcpowermac
+- mtulio
+- rvanderp3
+- vr4manta
+- sgaoshang
+- WenXinWei

--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ Canonical repo for nested-ova-ansible in CI. Provisions nested vCenter and ESXi 
 - `MEMORY`                   - optional: the amount of memory in GB assigned to the nested VMs. The resources required for the vCenter(s) are not to be included. The default is 96 GB
 - `DISKGB`                   - optional: the amount of disk space in GB assigned to the nested host local datastore. The resources required for the vCenter(s) are not to be included. The default is 1024 GB
 
+#### Optional: Pin created VMs to specific hosts (VM-Host DRS rule)
+
+If you want each created nested ESXi VM to be locked to a specific outer vSphere host, enable VM-Host DRS pinning. When enabled, for each ESXi VM we create a Host DRS group (with the selected host), a VM DRS group (with the VM), and a VM-Host DRS rule that is enabled and mandatory by default.
+
+Control via the following env vars:
+
+- `PIN_VMS_TO_HOSTS`  - Set to `true` to enable pinning. Default: `false`.
+- `PIN_HOSTS`         - Comma-separated list of ESXi host names in the outer cluster (e.g. `esx01.lab.local,esx02.lab.local`). VMs are assigned round-robin by index.
+- `PIN_MANDATORY`     - `true` for a mandatory "Must run on hosts in group" rule; `false` for a preferential rule. Default: `true`.
+
+Notes:
+- Pinning is applied during VM provisioning in `esxinested.yml` using `community.vmware.vmware_drs_group` and `community.vmware.vmware_vm_host_drs_rule`.
+- Ensure each host listed in `PIN_HOSTS` exists in the target cluster and has capacity for the pinned VM(s).
+
 ### Defining Media Assets
 
 Bespoke versions of vCenter and ESXi can deployed by defining elements in the `vc_assets` list in `group_vars/all.yml`. For example:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nested-ova-ansible
 
-Provisions nested vCenter and ESXi hosts.
+Canonical repo for nested-ova-ansible in CI. Provisions nested vCenter and ESXi hosts.
 
 ## Prerequisites
 

--- a/esxinested.yml
+++ b/esxinested.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: List hosts in ESXi
   ansible.builtin.debug:
     msg: "Host: {{ item }}"
@@ -38,12 +37,12 @@
         state: poweredoff
         cluster: "{{ vc_cluster | split('/') | last }}"
         datacenter: "{{ vc_datacenter }}"
-        name: '{{ host_fact_hostname }}'
+        name: "{{ host_fact_hostname }}"
         folder: "{{ vc_folder }}"
         datastore: "{{ vc_datastore }}"
         vapp_properties:
-        - id: guestinfo.password
-          value: "{{ vc_fact_password }}" # SSO Password for administrator@vsphere.local
+          - id: guestinfo.password
+            value: "{{ vc_fact_password }}" # SSO Password for administrator@vsphere.local
         hardware:
           memory_mb: "{{ esximemory }}"
           num_cpu_cores_per_socket: "{{ esxicpu }}"
@@ -63,7 +62,7 @@
     state: present
     network_name: "{{ item.network_name | default(omit) }}"
     connected: "{{ item.connected | default(omit) }}"
-    label:  "{{ item.label | default(omit) }}"
+    label: "{{ item.label | default(omit) }}"
     device_type: vmxnet3
   loop:
     - network_name: "{{ vc_fact_deployment_network }}"
@@ -82,13 +81,56 @@
         controller_number: "{{ item.controller_number }}"
         controller_type: "{{ item.controller_type }}"
         size_gb: 1024
-        type: 'thin'
+        type: "thin"
     state: present
   loop:
     - unit_number: 2
       controller_number: 0
       controller_type: "paravirtual"
 
+# Optionally pin this VM to a specific host via a VM-Host DRS rule
+- name: Compute target host for VM pinning
+  ansible.builtin.set_fact:
+    pin_hosts_clean: "{{ vc_pin_hosts | map('trim') | list }}"
+  when: vc_pin_vms_to_hosts == 'true' and (vc_pin_hosts | length) > 0
+
+- name: Select host in round-robin for VM pinning
+  ansible.builtin.set_fact:
+    selected_pin_host: "{{ pin_hosts_clean[(my_idx | int) % (pin_hosts_clean | length)] }}"
+  when: vc_pin_vms_to_hosts == 'true' and (vc_pin_hosts | length) > 0
+
+- name: Create Host DRS group for pinning
+  community.vmware.vmware_drs_group:
+    datacenter: "{{ vc_datacenter }}"
+    cluster_name: "{{ vc_cluster | split('/') | last }}"
+    group_name: "{{ host_fact_hostname }}-hostgrp"
+    hosts:
+      - "{{ selected_pin_host }}"
+    state: present
+  when: vc_pin_vms_to_hosts == 'true' and (vc_pin_hosts | length) > 0
+
+- name: Create VM DRS group for pinning
+  community.vmware.vmware_drs_group:
+    datacenter: "{{ vc_datacenter }}"
+    cluster_name: "{{ vc_cluster | split('/') | last }}"
+    group_name: "{{ host_fact_hostname }}-vmgrp"
+    vms:
+      - "{{ host_fact_hostname }}"
+    state: present
+  when: vc_pin_vms_to_hosts == 'true' and (vc_pin_hosts | length) > 0
+
+- name: Create VM-Host DRS rule to pin VM to host
+  community.vmware.vmware_vm_host_drs_rule:
+    datacenter: "{{ vc_datacenter }}"
+    cluster_name: "{{ vc_cluster | split('/') | last }}"
+    drs_rule_name: "{{ host_fact_hostname }}-pin-to-{{ selected_pin_host }}"
+    vm_group_name: "{{ host_fact_hostname }}-vmgrp"
+    host_group_name: "{{ host_fact_hostname }}-hostgrp"
+    affinity_rule: true
+    mandatory: "{{ vc_pin_mandatory | bool }}"
+    enabled: true
+    state: present
+  when: vc_pin_vms_to_hosts == 'true' and (vc_pin_hosts | length) > 0
 
 - name: "poweron virtual machine {{ host_fact_hostname }} version {{ version }}"
   community.vmware.vmware_guest:
@@ -117,7 +159,7 @@
     datacenter: "{{ vc_datacenter }}"
     name: "{{ host_fact_hostname }}"
   register: nested_vm
-  until: nested_vm.instance.ipv4 != None 
+  until: nested_vm.instance.ipv4 != None
   retries: 10
   delay: 30
 
@@ -127,7 +169,7 @@
 
 - name: Add host to group esxi
   ansible.builtin.add_host:
-    name: '{{ host_fact_hostname }}'
+    name: "{{ host_fact_hostname }}"
     groups: esxi
     NESTEDVMIP: "{{ nested_vm.instance.ipv4 }}"
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -21,28 +21,40 @@ vc_allocated_disk: "{{ lookup('ansible.builtin.env', 'DISKGB', default=1024) }}"
 vc_skip_tagging: "{{ lookup('ansible.builtin.env', 'SKIP_FAILURE_DOMAIN_TAGGING', default='false') }}"
 vc_vcenter_host_map: {}
 
-vc_nfs_shares: 
-- {
-  "server": "161.26.99.159",
-  "name": "dsnested",
-  "path": "/DSW02SEV2284482_22/data01",
-  'type': 'nfs41', 
-  'nfs_ro': 'true'
-}
+vc_nfs_shares:
+  - {
+      "server": "161.26.99.159",
+      "name": "dsnested",
+      "path": "/DSW02SEV2284482_22/data01",
+      "type": "nfs41",
+      "nfs_ro": "true",
+    }
 
-vc_assets: 
-- {
-  'name': 'VC7.0.3.01400-21477706-ESXi7.0u3q',
-  'esxiova': 'Nested_ESXi7.0u3q_Appliance_Template_v1.ova',
-  'vcenterova': 'VMware-vCenter-Server-Appliance-7.0.3.01400-21477706_OVF10.ova',
-  'httpova': "10.93.245.232:8080"
-}
-- {
-  'name': 'VC8.0.2.00100-22617221-ESXi8.0u2c', 
-  'esxiova': 'Nested_ESXi8.0u2c_Appliance_Template_v1.ova',
-  'vcenterova': 'VMware-vCenter-Server-Appliance-8.0.2.00100-22617221_OVF10.ova',
-  'httpova': "10.93.245.232:8080",
-  'default': "true"
-}
+vc_assets:
+  - {
+      "name": "VC7.0.3.01400-21477706-ESXi7.0u3q",
+      "esxiova": "Nested_ESXi7.0u3q_Appliance_Template_v1.ova",
+      "vcenterova": "VMware-vCenter-Server-Appliance-7.0.3.01400-21477706_OVF10.ova",
+      "httpova": "10.93.245.232:8080",
+    }
+  - {
+      "name": "VC8.0.2.00100-22617221-ESXi8.0u2c",
+      "esxiova": "Nested_ESXi8.0u2c_Appliance_Template_v1.ova",
+      "vcenterova": "VMware-vCenter-Server-Appliance-8.0.2.00100-22617221_OVF10.ova",
+      "httpova": "10.93.245.232:8080",
+      "default": "true",
+    }
 
 ###### ADDITIONAL VARIABLES MAYBE DEFINED OR CHANGED BY DEFINING /tmp/override-vars.yaml ######
+
+# Optional: pin created VMs to specific hosts in the outer vCenter cluster
+# Enable with env PIN_VMS_TO_HOSTS=true
+vc_pin_vms_to_hosts: "{{ lookup('ansible.builtin.env', 'PIN_VMS_TO_HOSTS', default='false') }}"
+
+# Comma-separated list of ESXi host names in the outer cluster to pin to (round-robin by VM index)
+# Example: PIN_HOSTS="esx01.lab.local,esx02.lab.local"
+vc_pin_hosts: "{{ (lookup('ansible.builtin.env', 'PIN_HOSTS', default='') | split(',')) | select('length') | list }}"
+
+# Whether the rule is mandatory (Must run) or preferential (Should run)
+# Enable with env PIN_MANDATORY=true|false (default true)
+vc_pin_mandatory: "{{ lookup('ansible.builtin.env', 'PIN_MANDATORY', default='true') }}"


### PR DESCRIPTION
This is to pin VM's to a single host while running a nested vSphere environment. The idea is this will speed up nesting latency as everyone knows nested environments have a lot of overhead for cpu/memory/disk/network. 